### PR TITLE
Get jQuery from Google CDN

### DIFF
--- a/firefox/defaults/preferences/firequery.js
+++ b/firefox/defaults/preferences/firequery.js
@@ -1,6 +1,6 @@
 pref("extensions.firebug.firequery.watcherInterval", 1000);
 
-pref("extensions.firebug.firequery.jQueryURL", 'chrome://firequery-resources/content/jquery.js');
+pref("extensions.firebug.firequery.jQueryURL", '//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js');
 pref("extensions.firebug.firequery.jQueryURLTimeout", 5000);
 
 pref("extensions.firebug.firequery.jQueryLintURL", 'chrome://firequery-resources/content/jquery.lint.js');


### PR DESCRIPTION
Hi Antonin,

I modified the preferences to get the latest version of jQuery from the Google CDN. This should help you avoid updating every time a new version is released.

Another option I considered is to add an option to use the local version or the CDN version. What do you think?
