### PR TITLE
Added support for Firefox 6

### DIFF
--- a/firefox/install.rdf
+++ b/firefox/install.rdf
@@ -10,7 +10,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>2.0</em:minVersion>
-        <em:maxVersion>5.*</em:maxVersion>
+        <em:maxVersion>6.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <!-- SeaMonkey -->


### PR DESCRIPTION
Hi, I love FireQuery and when I updated to FireFox 6 today I noticed FireQuery wouldn't work. Forked the source  modified the supported versions, rebuilt and tested with FireFox 6. Looks like it works good :)
